### PR TITLE
Don't import vars from setup.py

### DIFF
--- a/ckanext/oauth2/__init__.py
+++ b/ckanext/oauth2/__init__.py
@@ -17,5 +17,3 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OAuth2 CKAN Extension.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = '0.3.7'
-__description__ = 'OAuth2 support for CKAN'

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ import re
 
 from setuptools import setup, find_packages
 
-from ckanext.oauth2 import __version__, __description__
-
+__version__ = '0.3.7'
+__description__ = 'OAuth2 support for CKAN'
 
 PYPI_RST_FILTERS = (
     # Remove travis ci badge


### PR DESCRIPTION
When using setuptools>=19.4 installation fails with an exception:

```
Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/home/adria/dev/pyenvs/fiware/src/ckanext-oauth2/setup.py", line 25, in <module>

    from ckanext.oauth2 import __version__, __description__

  File "ckanext/__init__.py", line 23, in <module>

    pkg_resources.declare_namespace(__name__)

  File "/home/adria/dev/pyenvs/fiware/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2229, in declare_namespace

    _handle_ns(packageName, path_item)

  File "/home/adria/dev/pyenvs/fiware/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2198, in _handle_ns

    path.sort(key=sort_key)

  File "/home/adria/dev/pyenvs/fiware/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2196, in sort_key

    return sys_path.index(_normalize_cached(os.sep.join(parts)))

ValueError: '/home/adria/dev/pyenvs/fiware/src/ckanext-oauth2' is not in list
```

This seems to be related with this setuptools issue:

https://bitbucket.org/pypa/setuptools/issues/491/setuptools-194-breaks-pip-install-builds

In any case, it can be avoided removing the imports from setup.py