### PR TITLE
Feature/improve missing conf error msg

### DIFF
--- a/ckanext/oauth2/oauth2.py
+++ b/ckanext/oauth2/oauth2.py
@@ -80,10 +80,9 @@ class OAuth2Helper(object):
         # Init db
         db.init_db(model)
 
-        if self.authorization_endpoint == "" or self.token_endpoint == "" or self.client_id == "" or self.client_secret == "" \
-                or self.profile_api_url == "" or self.profile_api_user_field == "" or self.profile_api_mail_field == "":
-            raise ValueError('authorization_endpoint, token_endpoint, client_id, client_secret, '
-                             'profile_api_url, profile_api_user_field and profile_api_mail_field are required')
+        missing = [key for key in REQUIRED_CONF if getattr(self, key, "") == ""]
+        if missing:
+            raise ValueError("Missing required oauth2 conf: %s" % ", ".join(missing))
         elif self.scope == "":
             self.scope = None
 

--- a/test-fiware.ini
+++ b/test-fiware.ini
@@ -32,7 +32,6 @@ ckan.tests.functional.test_cache.TestCacheBasics.test_get_cache_expires.expires 
 ckan.plugins = oauth2
 
 ## OAuth2 configuration
-ckan.oauth2.logout_url = /user/logged_out
 ckan.oauth2.register_url = https://localhost/sign_up
 ckan.oauth2.reset_url = https://localhost/password/request
 ckan.oauth2.edit_url = https://localhost/idm/settings

--- a/test.ini
+++ b/test.ini
@@ -32,7 +32,6 @@ ckan.tests.functional.test_cache.TestCacheBasics.test_get_cache_expires.expires 
 ckan.plugins = oauth2
 
 ## OAuth2 configuration
-ckan.oauth2.logout_url = /user/logged_out
 ckan.oauth2.register_url = https://account.lab.fiware.org/sign_up
 ckan.oauth2.reset_url = https://account.lab.fiware.org/password/request
 ckan.oauth2.edit_url = https://account.lab.fiware.org/settings


### PR DESCRIPTION
Currently, the plugin raises a `ValueError` exception with a generic message if some of the required configuration values is missing. But there are several required configuration settings, so is hard to know what setting is missing.

This PR improves this error message so it states the configuration settings that are missing.