### PR TITLE
Using the Authorization header on the get_token method is only required when using a legacy version of KeyRock

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -2,6 +2,25 @@
 
 set -e
 
+function test_connection {
+    echo "Testing $1 connection"
+
+    attempt_counter=0
+    max_attempts=50
+
+    until $(curl --output /dev/null --silent --head --fail --insecure $2); do
+        if [ ${attempt_counter} -eq ${max_attempts} ];then
+            echo "Max attempts reached"
+            exit 1
+        fi
+
+        attempt_counter=$(($attempt_counter+1))
+        sleep 5
+    done
+
+    echo "$1 connection, OK"
+}
+
 echo "This is travis-build.bash..."
 
 echo "Installing the packages that CKAN requires..."
@@ -58,7 +77,7 @@ if [ "$INTEGRATION_TEST" = "true" ]; then
     docker run -d -p 443:443 --network main -e DATABASE_HOST=mysql -v "${TRAVIS_BUILD_DIR}/ci/idm-config.js:/opt/fiware-idm/config.js:ro" -v /etc/ssl/self_signed.key:/opt/fiware-idm/certs/self_signed.key:ro -v /usr/local/share/ca-certificates/self_signed.crt:/opt/fiware-idm/certs/self_signed.crt:ro --name idm fiware/idm
 
     # Wait until idm is ready
-    sleep 30
+    test_connection 'KeyRock' https://localhost:443
 fi
 
 echo "travis-build.bash is done."

--- a/ci/idm-config.js
+++ b/ci/idm-config.js
@@ -38,10 +38,13 @@ config.api = {
 }
 
 // Enable authzforce
-config.authzforce = {
-	enabled: false,
-	host: '',
-	port: 8080
+config.authorization = {
+    level: 'basic',
+    authzforce: {
+        enabled: false,
+        host: '',
+        port: 8080
+    }
 }
 
 var database_host = (process.env.DATABASE_HOST) ? process.env.DATABASE_HOST : 'localhost'
@@ -85,5 +88,13 @@ config.site = {
     title: 'Identity Manager',
     theme: 'default'
 };
+
+// Config eIDAs Authentication
+config.eidas = {
+    enabled: false,
+    gateway_host: 'localhost',
+    idp_host: 'https://se-eidas.redsara.es/EidasNode/ServiceProvider',
+    metadata_expiration: 60 * 60 * 24 * 365 // One year
+}
 
 module.exports = config;

--- a/ckanext/oauth2/oauth2.py
+++ b/ckanext/oauth2/oauth2.py
@@ -102,10 +102,14 @@ class OAuth2Helper(object):
         headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/x-www-form-urlencoded',
-            'Authorization': 'Basic %s' % base64.urlsafe_b64encode(
+        }
+
+        if self.legacy_idm:
+            # This is only required for Keyrock v6 and v5
+            headers['Authorization'] = 'Basic %s' % base64.urlsafe_b64encode(
                 '%s:%s' % (self.client_id, self.client_secret)
             )
-        }
+
         try:
             token = oauth.fetch_token(self.token_endpoint,
                                       headers=headers,


### PR DESCRIPTION
Current implementation provides an Authorization header with the client id and client secret using base64 encoding.

We have tested the following services with the following results:
- KeyRock v5 and v6. Needs the Authorization header when requesting access tokens.
- Github and KeyRock v7 does not required the Authorization header but works if you use it (problably this header get ignored).
- WSO2-IS refuses to give a token if you use this header as the credentials are sent on the body, so they complain about repeated credentials.

This PR change the code so this header is only used when connecting to a legacy version of the IdM. Should fix #22.